### PR TITLE
Typo: change from 'Presence (%)' to 'Presence prop. (%)'

### DIFF
--- a/Functionnectome/whiteRest.py
+++ b/Functionnectome/whiteRest.py
@@ -305,7 +305,7 @@ def computPresence(ROI_f, atlas_f, RSNlabels_f, zThresh=7, binarize=False):
                               presenceProp[i],  # Presence (%)
                               presenceRaw[i],  # Presence (raw)
                               coverage[i]]  # Coverage
-    resPresence.sort_values('Presence (%)', ascending=False, inplace=True, ignore_index=True)
+    resPresence.sort_values('Presence prop. (%)', ascending=False, inplace=True, ignore_index=True)
     return resPresence
 
 


### PR DESCRIPTION
This typo will cause an error and terminate the process when sorting the results of the 'Presence' analysis. For details please see lines 280, 305 and 308 of the script 'whiteRest.py'.